### PR TITLE
Add medusa command to calculate backup size

### DIFF
--- a/medusa/calculate_size.py
+++ b/medusa/calculate_size.py
@@ -1,15 +1,14 @@
 import json
 import logging
 
-from typing import List
-
 from medusa.storage import Storage
 
 
-def calculate_size(config, backup_names: List[str], exclude_two_backups: bool):
+def calculate_size(config, backup_names, exclude_backups):
     storage = Storage(config=config.storage)
 
-    valid_backups = []
+    size_map = {}
+
     for backup_name in backup_names:
         node_backup = storage.get_node_backup(fqdn=storage.config.fqdn, name=backup_name)
 
@@ -22,34 +21,21 @@ def calculate_size(config, backup_names: List[str], exclude_two_backups: bool):
             logging.warning('No manifest found for backup {}'.format(backup_name))
             continue
 
-        valid_backups.append(backup_name)
-
-    include_backups = valid_backups
-    exclude_backups = []
-    if exclude_two_backups:
-        include_backups = valid_backups[:-2]
-        exclude_backups = valid_backups[-2:]
-
-    logging.info("Including backups: {}".format(include_backups))
-    logging.info("Excluding backups: {}".format(exclude_backups))
-
-    _calculate_size(config, include_backups, exclude_backups)
-
-
-def _calculate_size(config, include_backups: List[str], exclude_backups: List[str]):
-    storage = Storage(config=config.storage)
-    size_map = {}
-
-    for backup_name in include_backups:
-        node_backup = storage.get_node_backup(fqdn=storage.config.fqdn, name=backup_name)
-        manifest = node_backup.manifest
         for section in json.loads(manifest):
             for obj in section['objects']:
                 size_map[obj['path']] = obj['size']
 
     for backup_name in exclude_backups:
         node_backup = storage.get_node_backup(fqdn=storage.config.fqdn, name=backup_name)
+        if not node_backup.exists():
+            logging.warning('No such backup {}'.format(backup_name))
+            continue
+
         manifest = node_backup.manifest
+        if manifest is None:
+            logging.warning('No manifest found for backup {}'.format(backup_name))
+            continue
+
         for section in json.loads(manifest):
             for obj in section['objects']:
                 if obj['path'] in size_map:

--- a/medusa/calculate_size.py
+++ b/medusa/calculate_size.py
@@ -1,14 +1,15 @@
 import json
 import logging
 
+from typing import List
+
 from medusa.storage import Storage
 
 
-def calculate_size(config, backup_names, exclude_backups):
+def calculate_size(config, backup_names: List[str], exclude_two_backups: bool):
     storage = Storage(config=config.storage)
 
-    size_map = {}
-
+    valid_backups = []
     for backup_name in backup_names:
         node_backup = storage.get_node_backup(fqdn=storage.config.fqdn, name=backup_name)
 
@@ -21,21 +22,34 @@ def calculate_size(config, backup_names, exclude_backups):
             logging.warning('No manifest found for backup {}'.format(backup_name))
             continue
 
+        valid_backups.append(backup_name)
+
+    include_backups = valid_backups
+    exclude_backups = []
+    if exclude_two_backups:
+        include_backups = valid_backups[:-2]
+        exclude_backups = valid_backups[-2:]
+
+    logging.info("Including backups: {}".format(include_backups))
+    logging.info("Excluding backups: {}".format(exclude_backups))
+
+    _calculate_size(config, include_backups, exclude_backups)
+
+
+def _calculate_size(config, include_backups: List[str], exclude_backups: List[str]):
+    storage = Storage(config=config.storage)
+    size_map = {}
+
+    for backup_name in include_backups:
+        node_backup = storage.get_node_backup(fqdn=storage.config.fqdn, name=backup_name)
+        manifest = node_backup.manifest
         for section in json.loads(manifest):
             for obj in section['objects']:
                 size_map[obj['path']] = obj['size']
 
     for backup_name in exclude_backups:
         node_backup = storage.get_node_backup(fqdn=storage.config.fqdn, name=backup_name)
-        if not node_backup.exists():
-            logging.warning('No such backup {}'.format(backup_name))
-            continue
-
         manifest = node_backup.manifest
-        if manifest is None:
-            logging.warning('No manifest found for backup {}'.format(backup_name))
-            continue
-
         for section in json.loads(manifest):
             for obj in section['objects']:
                 if obj['path'] in size_map:

--- a/medusa/calculate_size.py
+++ b/medusa/calculate_size.py
@@ -1,0 +1,44 @@
+import json
+import logging
+
+from medusa.storage import Storage
+
+
+def calculate_size(config, backup_names, exclude_backups):
+    storage = Storage(config=config.storage)
+
+    size_map = {}
+
+    for backup_name in backup_names:
+        node_backup = storage.get_node_backup(fqdn=storage.config.fqdn, name=backup_name)
+
+        if not node_backup.exists():
+            logging.warning('No such backup {}'.format(backup_name))
+            continue
+
+        manifest = node_backup.manifest
+        if manifest is None:
+            logging.warning('No manifest found for backup {}'.format(backup_name))
+            continue
+
+        for section in json.loads(manifest):
+            for obj in section['objects']:
+                size_map[obj['path']] = obj['size']
+
+    for backup_name in exclude_backups:
+        node_backup = storage.get_node_backup(fqdn=storage.config.fqdn, name=backup_name)
+        if not node_backup.exists():
+            logging.warning('No such backup {}'.format(backup_name))
+            continue
+
+        manifest = node_backup.manifest
+        if manifest is None:
+            logging.warning('No manifest found for backup {}'.format(backup_name))
+            continue
+
+        for section in json.loads(manifest):
+            for obj in section['objects']:
+                if obj['path'] in size_map:
+                    del size_map[obj['path']]
+
+    logging.info("Total size of backups: {} bytes".format(sum(size_map.values())))

--- a/medusa/calculate_size.py
+++ b/medusa/calculate_size.py
@@ -41,4 +41,4 @@ def calculate_size(config, backup_names, exclude_backups):
                 if obj['path'] in size_map:
                     del size_map[obj['path']]
 
-    logging.info("Total size of backups: {} bytes".format(sum(size_map.values())))
+    print("Total size of backups: {} bytes".format(sum(size_map.values())))

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -368,9 +368,12 @@ def delete_backup(medusaconfig, backup_name, all_nodes):
 @cli.command(name='get-size', help='Calculate the size of the given backup on the current node')
 @click.option('--backup-name', help='Backup name (repeat for multiple names)', required=True, multiple=True)
 @click.option('--exclude-backup', help='Exclude the files of the given backups from the calculation (repeat for multiple names)', required=False, multiple=True)
+@click.option('--exclude-two-backups', help='Exclude the files of two backups from the calculation', required=False, default=False, is_flag=True)
 @pass_MedusaConfig
-def calculate_size(medusaconfig, backup_name, exclude_backup):
+def calculate_size(medusaconfig, backup_name, exclude_backup, exclude_two_backups):
     """
     Calculate the size of the given backups on the current node
     """
-    medusa.calculate_size.calculate_size(medusaconfig, backup_name, exclude_backup)
+    if exclude_backup:
+        exclude_two_backups = True
+    medusa.calculate_size.calculate_size(medusaconfig, backup_name + exclude_backup, exclude_two_backups)

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -367,7 +367,9 @@ def delete_backup(medusaconfig, backup_name, all_nodes):
 
 @cli.command(name='get-size', help='Calculate the size of the given backup on the current node')
 @click.option('--backup-name', help='Backup name (repeat for multiple names)', required=True, multiple=True)
-@click.option('--exclude-backup', help='Exclude the files of the given backups from the calculation (repeat for multiple names)', required=False, multiple=True)
+@click.option('--exclude-backup',
+              help='Exclude the files of the given backups from the calculation (repeat for multiple names)',
+              required=False, multiple=True)
 @pass_MedusaConfig
 def calculate_size(medusaconfig, backup_name, exclude_backup):
     """

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -49,6 +49,7 @@ import medusa.restore_node
 import medusa.status
 import medusa.verify
 import medusa.fetch_tokenmap
+import medusa.calculate_size
 
 pass_MedusaConfig = click.make_pass_decorator(medusa.config.MedusaConfig)
 
@@ -362,3 +363,14 @@ def delete_backup(medusaconfig, backup_name, all_nodes):
     Delete the given backup on the current node (or on all nodes)
     """
     medusa.purge.delete_backup(medusaconfig, backup_name, all_nodes)
+
+
+@cli.command(name='get-size', help='Calculate the size of the given backup on the current node')
+@click.option('--backup-name', help='Backup name (repeat for multiple names)', required=True, multiple=True)
+@click.option('--exclude-backup', help='Exclude the files of the given backups from the calculation (repeat for multiple names)', required=False, multiple=True)
+@pass_MedusaConfig
+def calculate_size(medusaconfig, backup_name, exclude_backup):
+    """
+    Calculate the size of the given backups on the current node
+    """
+    medusa.calculate_size.calculate_size(medusaconfig, backup_name, exclude_backup)

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -368,12 +368,9 @@ def delete_backup(medusaconfig, backup_name, all_nodes):
 @cli.command(name='get-size', help='Calculate the size of the given backup on the current node')
 @click.option('--backup-name', help='Backup name (repeat for multiple names)', required=True, multiple=True)
 @click.option('--exclude-backup', help='Exclude the files of the given backups from the calculation (repeat for multiple names)', required=False, multiple=True)
-@click.option('--exclude-two-backups', help='Exclude the files of two backups from the calculation', required=False, default=False, is_flag=True)
 @pass_MedusaConfig
-def calculate_size(medusaconfig, backup_name, exclude_backup, exclude_two_backups):
+def calculate_size(medusaconfig, backup_name, exclude_backup):
     """
     Calculate the size of the given backups on the current node
     """
-    if exclude_backup:
-        exclude_two_backups = True
-    medusa.calculate_size.calculate_size(medusaconfig, backup_name + exclude_backup, exclude_two_backups)
+    medusa.calculate_size.calculate_size(medusaconfig, backup_name, exclude_backup)


### PR DESCRIPTION
This PR introduces a new command to calculate the size of backups.

When dealing with differential backups, simply summing up the sizes of each backup does not provide an accurate total size.

To address this, the command utilizes the manifest files associated with the given backups. The manifest file contains information such as the filename, size, and MD5 hash for each C* file. By iterating over these manifest files, the command stores each C* file name and its size in a map, eliminating any duplicate entries. Finally, the sizes of the files in the map are summed up to determine the overall backup size.
