### PR TITLE
Attach 32 random characters to each sstable identifier

### DIFF
--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -372,7 +372,10 @@ def check_already_uploaded(
         else:
             # safe_table_name is either a table, or a "table.2i_name"
             _, safe_table_name = Storage.sanitize_keyspace_and_table_name(src)
-            item_in_storage = keyspace_files_in_storage.get(safe_table_name, {}).get(src.name, None)
+            table_files_in_storage = keyspace_files_in_storage.get(safe_table_name, {})
+            item_in_storage = [v for (k, v) in table_files_in_storage.items()
+                               if medusa.utils.remove_suffix(k) == src.name]
+            item_in_storage = item_in_storage[0] if len(item_in_storage) > 0 else None
             # object is not in storage
             if item_in_storage is None:
                 needs_backup.append(src)

--- a/medusa/storage/local_storage.py
+++ b/medusa/storage/local_storage.py
@@ -22,6 +22,7 @@ import pathlib
 import typing as t
 from pathlib import Path
 
+import medusa.utils
 from medusa.storage.abstract_storage import AbstractStorage, AbstractBlob, ManifestObject, ObjectDoesNotExistError
 
 
@@ -100,6 +101,7 @@ class LocalStorage(AbstractStorage):
 
         src_path = Path(src)
         dest_file = AbstractStorage.path_maybe_with_parent(dest, src_path)
+        dest_file = medusa.utils.remove_suffix(dest_file)
 
         logging.debug(
             '[Local Storage] Downloading {} -> {}'.format(
@@ -121,7 +123,7 @@ class LocalStorage(AbstractStorage):
         src_path = Path(src)
 
         # check if objects resides in a sub-folder (e.g. secondary index). if it does, use the sub-folder in object path
-        dest_file = self.root_dir / AbstractStorage.path_maybe_with_parent(dest, src_path)
+        dest_file = self.root_dir / medusa.utils.append_suffix(AbstractStorage.path_maybe_with_parent(dest, src_path))
 
         file_size = os.stat(src_path).st_size
         logging.debug(

--- a/medusa/utils.py
+++ b/medusa/utils.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import logging
+import secrets
+import string
 import sys
 import pathlib
 import traceback
@@ -21,7 +23,6 @@ import tempfile
 
 
 class MedusaTempFile(object):
-
     _tempfile = None
     _tempfile_path = f'{tempfile.gettempdir()}/medusa_backup_in_progress'
 
@@ -85,3 +86,21 @@ def null_if_empty(value):
     if (str(value) == ''):
         return None
     return value
+
+
+SUFFIX_LENGTH = 32
+
+
+def append_suffix(file_name):
+    alphabet = string.ascii_letters + string.digits
+    suffix = ''.join(secrets.choice(alphabet) for _ in range(SUFFIX_LENGTH))
+
+    return file_name + suffix
+
+
+def remove_suffix(file_name):
+    # if ext is longer than SUFFIX_LENGTH characters, it means SUFFIX_LENGTH characters suffix was appended
+    if len(file_name.split('.')[-1]) >= SUFFIX_LENGTH:
+        file_name = file_name[:len(file_name) - SUFFIX_LENGTH]
+
+    return file_name

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -1101,7 +1101,7 @@ Feature: Integration tests
     | s3_us_west_oregon | without_client_encryption |
 
     @30
-    Scenario Outline: Create an differential backup, corrupt it, then fix by doing another backup, and verify it
+    Scenario Outline: Create an differential backup, corrupt it, then do another backup, and verify it
         Given I have a fresh ccm cluster "<client encryption>" running named "scenario30"
         Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
         When I create the "test" table with secondary index in keyspace "medusa"
@@ -1111,14 +1111,14 @@ Feature: Integration tests
         And I "delete" a random sstable from "differential" backup "first_backup" in the "test" table in keyspace "medusa"
         Then verifying backup "first_backup" fails
         When I perform a backup in "differential" mode of the node named "second_backup" with md5 checks "disabled"
-        Then I can verify the backup named "first_backup" with md5 checks "enabled" successfully
+        Then verifying backup "first_backup" fails
         Then I can verify the backup named "second_backup" with md5 checks "enabled" successfully
         And I "truncate" a random sstable from "differential" backup "second_backup" in the "test" table in keyspace "medusa"
         Then verifying backup "second_backup" fails
         When I perform a backup in "differential" mode of the node named "fourth_backup" with md5 checks "enabled"
         Then some files from the previous backup were not reuploaded
         Then some files from the previous backup "were" replaced
-        Then I can verify the backup named "second_backup" with md5 checks "enabled" successfully
+        Then verifying backup "second_backup" fails
         Then I can verify the backup named "fourth_backup" with md5 checks "enabled" successfully
         When I delete the backup named "first_backup"
         Then I cannot see the backup named "first_backup" when I list the backups


### PR DESCRIPTION
Before C* 4.1, sstable identifiers are not globally unique. To address this issue, we attach 32 random characters to each sstable identifier in Azure Blob Storage.