### PR TITLE
Use identity id for Azure credentials

### DIFF
--- a/docs/azure_blobs_setup.md
+++ b/docs/azure_blobs_setup.md
@@ -3,7 +3,10 @@ Azure Blob Storage setup
 
 ### Storage account
 
-Create a new storage account or use an existing one which will be used to store the backups. Ideally, do not enable public access. Under the `Settings`, find `Access keys`. Note the `storageaccountname` and `Key`. Create a file called `medusa-azure-credentials` in the following format:
+// TODO: update doc
+Create a new storage account or use an existing one which will be used to store the backups. 
+Ideally, do not enable public access. Under the `Settings`, find `Access keys`. 
+Note the `storageaccountname` and `Key`. Create a file called `medusa-azure-credentials` in the following format:
 
 ```json
 {

--- a/docs/azure_blobs_setup.md
+++ b/docs/azure_blobs_setup.md
@@ -3,7 +3,6 @@ Azure Blob Storage setup
 
 ### Storage account
 
-// TODO: update doc
 Create a new storage account or use an existing one which will be used to store the backups. 
 Ideally, do not enable public access. Under the `Settings`, find `Access keys`. 
 Note the `storageaccountname` and `Key`. Create a file called `medusa-azure-credentials` in the following format:
@@ -14,6 +13,19 @@ Note the `storageaccountname` and `Key`. Create a file called `medusa-azure-cred
     "key": "YOUR_KEY"
 }
 ```
+
+Instead of using storage key, you can use Azure AD credentials. 
+To do so, the format of the `medusa-azure-credentials` file should be:
+
+```json
+{
+  "storage_account": "YOUR_STORAGE_ACCOUNT_NAME",
+  "identity_config": {
+    "mi_res_id": "MANAGED_IDENTITY_RESOURCE_ID"
+  }
+}
+```
+  
 Place this file on all Apache Cassandra™ nodes running medusa under `/etc/medusa/`and set the rights appropriately so that only users running Medusa can read/modify it.
 
 ### Create a container

--- a/tests/storage/azure_storage_test.py
+++ b/tests/storage/azure_storage_test.py
@@ -113,7 +113,6 @@ class AzureStorageTest(unittest.TestCase):
             "storage_account": "medusa-unit-test",
             "key": "randomString==",
             "blob_url": "https://xxx.blob.host.net/"
-                        >>>>>>> nova_0.13.13
         }
         """
         with tempfile.NamedTemporaryFile() as credentials_file:

--- a/tests/storage/azure_storage_test.py
+++ b/tests/storage/azure_storage_test.py
@@ -83,6 +83,32 @@ class AzureStorageTest(unittest.TestCase):
                 azure_storage.azure_blob_service_url
             )
 
+    def test_credentials_with_blob_url(self):
+        credentials_file_content_with_identity_config = """
+        {
+            "storage_account": "medusa-unit-test",
+            "key": "randomString==",
+            "blob_url": "https://xxx.blob.host.net/"
+        }
+        """
+        with tempfile.NamedTemporaryFile() as credentials_file:
+            credentials_file.write(credentials_file_content_with_identity_config.encode())
+            credentials_file.flush()
+            config = AttributeDict({
+                'region': 'region-from-config',
+                'storage_provider': 'azure_blobs',
+                'key_file': credentials_file.name,
+                'bucket_name': 'bucket-from-config',
+                'concurrent_transfers': '1',
+                'host': None,
+                'port': None,
+            })
+            azure_storage = AzureStorage(config)
+            self.assertEqual(
+                'https://xxx.blob.host.net/',
+                azure_storage.azure_blob_service_url
+            )
+
     def test_credentials_with_managed_identity(self):
         credentials_file_content_with_identity_config = """
         {
@@ -106,31 +132,3 @@ class AzureStorageTest(unittest.TestCase):
             })
             azure_storage = AzureStorage(config)
             self.assertTrue(isinstance(azure_storage.credentials, ManagedIdentityCredential))
-
-    def test_credentials_with_blob_url(self):
-        credentials_file_content_with_identity_config = """
-        {
-            "storage_account": "medusa-unit-test",
-            "key": "randomString==",
-            "blob_url": "https://xxx.blob.host.net/"
-        }
-        """
-        with tempfile.NamedTemporaryFile() as credentials_file:
-            credentials_file.write(credentials_file_content_with_identity_config.encode())
-            credentials_file.flush()
-            config = AttributeDict({
-                'region': 'region-from-config',
-                'storage_provider': 'azure_blobs',
-                'key_file': credentials_file.name,
-                'bucket_name': 'bucket-from-config',
-                'concurrent_transfers': '1',
-                'host': None,
-                'port': None,
-            })
-            azure_storage = AzureStorage(config)
-
-            self.assertEqual(
-                'https://xxx.blob.host.net/',
-                azure_storage.azure_blob_service_url
-            )
-

--- a/tests/storage/azure_storage_test.py
+++ b/tests/storage/azure_storage_test.py
@@ -10,6 +10,8 @@ import unittest
 
 from medusa.storage.azure_storage import AzureStorage
 from tests.storage.abstract_storage_test import AttributeDict
+from azure.identity import ManagedIdentityCredential
+from azure.core.credentials import AzureNamedKeyCredential
 
 
 class AzureStorageTest(unittest.TestCase):
@@ -35,6 +37,9 @@ class AzureStorageTest(unittest.TestCase):
                 'port': None,
             })
             azure_storage = AzureStorage(config)
+            self.assertTrue(isinstance(azure_storage.credentials, AzureNamedKeyCredential))
+            self.assertEqual("medusa-unit-test", azure_storage.credentials.named_key.name)
+            self.assertEqual("randomString==", azure_storage.credentials.named_key.key)
             self.assertEqual(
                 'https://medusa-unit-test.blob.core.windows.net/',
                 azure_storage.azure_blob_service_url
@@ -77,3 +82,27 @@ class AzureStorageTest(unittest.TestCase):
                 'https://medusa-unit-test.blob.core.custom.host.net:123/',
                 azure_storage.azure_blob_service_url
             )
+
+    def test_credentials_with_managed_identity(self):
+        credentials_file_content_with_identity_config = """
+        {
+          "storage_account": "medusa-unit-test",
+          "identity_config": {
+            "mi_res_id": "<managed_identity>"
+          }
+        }
+        """
+        with tempfile.NamedTemporaryFile() as credentials_file:
+            credentials_file.write(credentials_file_content_with_identity_config.encode())
+            credentials_file.flush()
+            config = AttributeDict({
+                'region': 'region-from-config',
+                'storage_provider': 'azure_blobs',
+                'key_file': credentials_file.name,
+                'bucket_name': 'bucket-from-config',
+                'concurrent_transfers': '1',
+                'host': None,
+                'port': None,
+            })
+            azure_storage = AzureStorage(config)
+            self.assertTrue(isinstance(azure_storage.credentials, ManagedIdentityCredential))


### PR DESCRIPTION
For security reasons, we're opting not to utilize storage keys as credentials. Instead, we'll be leveraging Azure AD Identity, specifically the resource ID of a managed identity. This PR introduces support for utilizing identity IDs for Azure credentials.
