### PR TITLE
Get token and schema from files

### DIFF
--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -222,7 +222,7 @@ def get_schema_and_tokenmap(cassandra, config):
 
     if not tokenmap:
         with cassandra.new_session() as cql_session:
-            tokenmap = cql_session.get_tokenmap()
+            tokenmap = cql_session.tokenmap()
 
     return schema, tokenmap
 

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -30,8 +30,10 @@ from medusa.backup_manager import BackupMan
 from medusa.cassandra_utils import Cassandra
 from medusa.index import add_backup_start_to_index, add_backup_finish_to_index, set_latest_backup_in_index
 from medusa.monitoring import Monitoring
+from medusa.network.hostname_resolver import HostnameResolver
 from medusa.storage import Storage, format_bytes_str, NodeBackup
 from medusa.storage.abstract_storage import ManifestObject
+from medusa.utils import evaluate_boolean
 
 
 def throttle_backup():
@@ -144,7 +146,7 @@ def start_backup(storage, node_backup, cassandra, differential_mode, stagger_tim
         logging.warning("Throttling backup impossible. It's probable that ionice is not available.")
 
     logging.info('Saving tokenmap and schema')
-    schema, tokenmap = get_schema_and_tokenmap(cassandra)
+    schema, tokenmap = get_schema_and_tokenmap(cassandra, config)
     node_backup.schema = schema
     node_backup.tokenmap = json.dumps(tokenmap)
 
@@ -195,10 +197,33 @@ def start_backup(storage, node_backup, cassandra, differential_mode, stagger_tim
 # Wait 2^i * 10 seconds between each retry, up to 2 minutes between attempts, which is right after the
 # attempt on which it waited for 60 seconds
 @retry(stop_max_attempt_number=7, wait_exponential_multiplier=10000, wait_exponential_max=120000)
-def get_schema_and_tokenmap(cassandra):
-    with cassandra.new_session() as cql_session:
-        schema = cql_session.dump_schema()
-        tokenmap = cql_session.tokenmap()
+def get_schema_and_tokenmap(cassandra, config):
+    schema, tokenmap = "", {}
+
+    if config.cassandra.schema_file:
+        with open(config.cassandra.schema_file, "r") as f:
+            schema = f.read()
+
+    if config.cassandra.token_file:
+        hostname_resolver = HostnameResolver(
+            resolve_addresses=evaluate_boolean(config.cassandra.resolve_ip_addresses),
+            k8s_mode=evaluate_boolean(config.kubernetes.enabled if config.kubernetes else False)
+        )
+        with open(config.cassandra.token_file, "r") as f:
+            tokenmap = json.load(f)
+            tokenmap = {
+                hostname_resolver.resolve_fqdn(ip): value
+                for ip, value in tokenmap.items()
+            }
+
+    if not schema:
+        with cassandra.new_session() as cql_session:
+            schema = cql_session.dump_schema()
+
+    if not tokenmap:
+        with cassandra.new_session() as cql_session:
+            tokenmap = cql_session.get_tokenmap()
+
     return schema, tokenmap
 
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -40,7 +40,7 @@ CassandraConfig = collections.namedtuple(
      'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 'nodetool_host',
      'nodetool_executable', 'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts',
      'sstableloader_tspw', 'sstableloader_ks', 'sstableloader_kspw', 'nodetool_ssl', 'resolve_ip_addresses', 'use_sudo',
-     'nodetool_flags', 'cql_k8s_secrets_path', 'nodetool_k8s_secrets_path']
+     'nodetool_flags', 'cql_k8s_secrets_path', 'nodetool_k8s_secrets_path', 'schema_file', 'token_file']
 )
 
 SSHConfig = collections.namedtuple(
@@ -138,7 +138,9 @@ def _build_default_config():
         'resolve_ip_addresses': 'True',
         'use_sudo': 'True',
         'nodetool_executable': 'nodetool',
-        'nodetool_flags': '-Dcom.sun.jndi.rmiURLParsing=legacy'
+        'nodetool_flags': '-Dcom.sun.jndi.rmiURLParsing=legacy',
+        'schema_file': '',
+        'token_file': ''
     }
 
     config['ssh'] = {

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -40,7 +40,8 @@ CassandraConfig = collections.namedtuple(
      'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 'nodetool_host',
      'nodetool_executable', 'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts',
      'sstableloader_tspw', 'sstableloader_ks', 'sstableloader_kspw', 'nodetool_ssl', 'resolve_ip_addresses', 'use_sudo',
-     'nodetool_flags', 'cql_k8s_secrets_path', 'nodetool_k8s_secrets_path', 'unix_socket_path', 'schema_file', 'token_file']
+     'nodetool_flags', 'cql_k8s_secrets_path', 'nodetool_k8s_secrets_path', 'unix_socket_path',
+     'schema_file', 'token_file']
 )
 
 SSHConfig = collections.namedtuple(

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -105,6 +105,8 @@ def configure_console_logging(verbosity, without_log_timestamp):
 @click.option('--backup-grace-period-in-days', help='Duration for which backup files cannot be deleted from storage')
 @click.option('--ssh-username')
 @click.option('--ssh-key-file')
+@click.option('--token-file')
+@click.option('--schema-file')
 @click.version_option(package_name='cassandra-medusa', message='%(version)s')
 @click.pass_context
 def cli(ctx, verbosity, without_log_timestamp, config_file, **kwargs):


### PR DESCRIPTION
Medusa uses python driver to connect to C* contact point (Unix socket) and then download token and schema. However, python driver could not create cql session via Unix socket for C* 4. Therefore, our workaround is to make backup sidecar to download token and schema to local files for C* 4 and make Medusa to read them from local files.